### PR TITLE
Add phoenix to umbrella/app_name/mix.exs

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -31,8 +31,11 @@ defmodule <%= app_module %>.Mixfile do
   #
   # Type `mix help deps` for examples and options.
   defp deps do
-    [<%= if ecto do %>{:<%= adapter_app %>, ">= 0.0.0"},
-     {:ecto, "~> 2.1"}<% end %>]
+    [<%= if ecto do %>
+     {:<%= adapter_app %>, ">= 0.0.0"},
+     {:ecto, "~> 2.1"},
+     {:phoenix, "~> 1.3.0-rc", only: :dev}
+    <% end %>]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.<%= if ecto do %>
@@ -42,8 +45,10 @@ defmodule <%= app_module %>.Mixfile do
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    [<%= if ecto do %>"ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+    [<%= if ecto do %>
+     "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
-     "test": ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>]
+     "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+    <% end %>]
   end
 end


### PR DESCRIPTION
This adds phoenix to the main application in an umbrella project. 
The purpose of this, is to make the generators available inside the main.
phoenix will be included for **dev** mode only, and only if **ecto** is enabled.